### PR TITLE
Add RUNAS_USER to control the user running resilio-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ to the docker start command
 This variable (along with RUNAS_UID, RUNAS_GROUP and RUNAS_GID) provide a way to control which user will run Resilio Sync and own the synced files.
 Useful when dealing with shared volumes.
 
+### LOG_TO_STDOUT
+
+The default logging uses file /var/log/rslsync.log.
+By defining the LOG_TO_STDOUT variable the Resilio Sync logs are outputted to stdout.
+
 ### syncing local files
 
 Inside the container the /data is the default sync directory, to link this to a local file system you can use the **-v** flag

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ To change maxmimum file size to 50 MB add
 
 to the docker start command
 
+### RUNAS_USER
+
+This variable (along with RUNAS_UID, RUNAS_GROUP and RUNAS_GID) provide a way to control which user will run Resilio Sync and own the synced files.
+Useful when dealing with shared volumes.
+
 ### syncing local files
 
 Inside the container the /data is the default sync directory, to link this to a local file system you can use the **-v** flag

--- a/root/etc/run_once/config_rslsync
+++ b/root/etc/run_once/config_rslsync
@@ -21,22 +21,39 @@ if [ -z $RSLSYNC_PATH ]; then
   RSLSYNC_PATH="/data"
 fi
 
+# prepare to run as a different user
+
+if [ -z $RUNAS_USER ]; then
+  USER_HOME="/home/$RUNAS_USER"
+  addgroup -g $RUNAS_GID -S $RUNAS_GROUP
+  adduser -u $RUNAS_UID -D -S -G $RUNAS_GROUP $RUNAS_USER
+
+  sed -i'' 's/root/$RUNAS_USER/' /etc/sv/rslsync/run
+
+  chown -R $RUNAS_USER /etc/rslsync
+  touch /var/log/rslsync.log && chown -R $RUNAS_USER /var/log/rslsync.log
+
+  chown -R $RUNAS_USER $RSLSYNC_PATH
+else
+  USER_HOME="/root"
+fi
+
 # create base configuration
 
 cat <<EOT > /etc/rslsync/rslsync.conf
 {
-  "storage_path" : "/root",
+  "storage_path" : "$USER_HOME",
   "listening_port" : 33333,
   "use_upnp" : false,
   "vendor" : "docker",
   "max_file_size_for_versioning" : $RSLSYNC_SIZE,
   "sync_trash_ttl" : $RSLSYNC_TRASH_TIME,
   "device_name" : "$RSLSYNC_NAME", 
-  "pid_file" : "/var/run/rslsync.pid",
+  "pid_file" : "$USER_HOME/rslsync.pid",
 EOT
 # check to see if webui should be activated
 
-if [ -z $RSLSYNC_USER ] ; then
+if [ -z $RSLSYNC_PASS ] ; then
   # non webui version
 
   echo "non-WEBUI mode activated, $RSLSYNC_PATH is synced"
@@ -70,7 +87,7 @@ EOT
 else
 
   echo "WEBUI mode activated"
-  if [ -z $RSLSYNC_PASS ]; then
+  if [ -z $RSLSYNC_USER ]; then
      RSLSYNC_PASS=`date +%s | sha256sum | base64 | head -c 10 ; echo`
      echo "RSLSYNC_PASS not set, password generated, use "$RSLSYNC_PASS" as password"
   fi

--- a/root/etc/run_once/config_rslsync
+++ b/root/etc/run_once/config_rslsync
@@ -53,7 +53,7 @@ cat <<EOT > /etc/rslsync/rslsync.conf
 EOT
 # check to see if webui should be activated
 
-if [ -z $RSLSYNC_PASS ] ; then
+if [ -z $RSLSYNC_USER ] ; then
   # non webui version
 
   echo "non-WEBUI mode activated, $RSLSYNC_PATH is synced"
@@ -87,7 +87,7 @@ EOT
 else
 
   echo "WEBUI mode activated"
-  if [ -z $RSLSYNC_USER ]; then
+  if [ -z $RSLSYNC_PASS ]; then
      RSLSYNC_PASS=`date +%s | sha256sum | base64 | head -c 10 ; echo`
      echo "RSLSYNC_PASS not set, password generated, use "$RSLSYNC_PASS" as password"
   fi

--- a/root/etc/run_once/config_rslsync
+++ b/root/etc/run_once/config_rslsync
@@ -33,7 +33,6 @@ else
   sed -i'' "s/root/$RUNAS_USER/" /etc/sv/rslsync/run
 
   chown -R $RUNAS_USER /etc/rslsync
-  touch /var/log/rslsync.log && chown -R $RUNAS_USER /var/log/rslsync.log
 
   chown -R $RUNAS_USER $RSLSYNC_PATH
 fi

--- a/root/etc/run_once/config_rslsync
+++ b/root/etc/run_once/config_rslsync
@@ -33,6 +33,10 @@ else
   sed -i'' "s/root/$RUNAS_USER/" /etc/sv/rslsync/run
 
   chown -R $RUNAS_USER /etc/rslsync
+  if [ -z $LOG_TO_STDOUT ]; then
+    touch /var/log/rslsync.log
+    chown -R $RUNAS_USER /var/log/rslsync.log
+  fi
 
   chown -R $RUNAS_USER $RSLSYNC_PATH
 fi

--- a/root/etc/run_once/config_rslsync
+++ b/root/etc/run_once/config_rslsync
@@ -24,18 +24,18 @@ fi
 # prepare to run as a different user
 
 if [ -z $RUNAS_USER ]; then
+  USER_HOME="/root"
+else
   USER_HOME="/home/$RUNAS_USER"
   addgroup -g $RUNAS_GID -S $RUNAS_GROUP
   adduser -u $RUNAS_UID -D -S -G $RUNAS_GROUP $RUNAS_USER
 
-  sed -i'' 's/root/$RUNAS_USER/' /etc/sv/rslsync/run
+  sed -i'' "s/root/$RUNAS_USER/" /etc/sv/rslsync/run
 
   chown -R $RUNAS_USER /etc/rslsync
   touch /var/log/rslsync.log && chown -R $RUNAS_USER /var/log/rslsync.log
 
   chown -R $RUNAS_USER $RSLSYNC_PATH
-else
-  USER_HOME="/root"
 fi
 
 # create base configuration

--- a/root/etc/run_once/config_rslsync
+++ b/root/etc/run_once/config_rslsync
@@ -30,8 +30,6 @@ else
   addgroup -g $RUNAS_GID -S $RUNAS_GROUP
   adduser -u $RUNAS_UID -D -S -G $RUNAS_GROUP $RUNAS_USER
 
-  sed -i'' "s/root/$RUNAS_USER/" /etc/sv/rslsync/run
-
   chown -R $RUNAS_USER /etc/rslsync
   if [ -z $LOG_TO_STDOUT ]; then
     touch /var/log/rslsync.log

--- a/root/etc/sv/rslsync/run
+++ b/root/etc/sv/rslsync/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-su -c "/usr/local/bin/rslsync --config /etc/rslsync/rslsync.conf --log /var/log/rslsync.log --nodaemon" -s /bin/sh root
+su -c "/usr/local/bin/rslsync --config /etc/rslsync/rslsync.conf --nodaemon" -s /bin/sh root

--- a/root/etc/sv/rslsync/run
+++ b/root/etc/sv/rslsync/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec /usr/local/bin/rslsync --config /etc/rslsync/rslsync.conf --log /var/log/rslsync.log --nodaemon
+su -c "/usr/local/bin/rslsync --config /etc/rslsync/rslsync.conf --log /var/log/rslsync.log --nodaemon" -s /bin/sh root

--- a/root/etc/sv/rslsync/run
+++ b/root/etc/sv/rslsync/run
@@ -1,7 +1,8 @@
 #!/bin/sh
 exec 2>&1
+source /etc/envvars
 LOG_LOCATION=""
 if [ -z $LOG_TO_STDOUT ]; then
   LOG_LOCATION=" --log /var/log/rslsync.log "
 fi
-su -c "/usr/local/bin/rslsync --config /etc/rslsync/rslsync.conf $LOG_LOCATION --nodaemon" -s /bin/sh root
+su -c "/usr/local/bin/rslsync --config /etc/rslsync/rslsync.conf $LOG_LOCATION --nodaemon" -s /bin/sh $RUNAS_USER

--- a/root/etc/sv/rslsync/run
+++ b/root/etc/sv/rslsync/run
@@ -1,3 +1,7 @@
 #!/bin/sh
 exec 2>&1
-su -c "/usr/local/bin/rslsync --config /etc/rslsync/rslsync.conf --nodaemon" -s /bin/sh root
+LOG_LOCATION=""
+if [ -z $LOG_TO_STDOUT ]; then
+  LOG_LOCATION=" --log /var/log/rslsync.log "
+fi
+su -c "/usr/local/bin/rslsync --config /etc/rslsync/rslsync.conf $LOG_LOCATION --nodaemon" -s /bin/sh root


### PR DESCRIPTION
Useful when dealing with shared volumes and we want to "reuse" the same user on different containers.